### PR TITLE
Add Option Inputs

### DIFF
--- a/examples/bounds.rs
+++ b/examples/bounds.rs
@@ -1,0 +1,33 @@
+use promptis::Input;
+
+fn main() {
+    let choice: Choice = Input::new()
+        .quit("quit")
+        .wait_opts(
+            &["Yes", "No"],
+            &format!("Do you want to hear the dog speak?\nYour choice: "),
+        )
+        .unwrap();
+
+    match choice {
+        Choice::Yes => println!("Bark!"),
+        Choice::No => println!("Awww ok :("),
+    }
+}
+
+enum Choice {
+    Yes,
+    No,
+}
+
+impl std::str::FromStr for Choice {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_uppercase().as_str() {
+            "YES" => Ok(Self::Yes),
+            "NO" => Ok(Self::No),
+            _ => Err(()),
+        }
+    }
+
+    type Err = ();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,62 @@ impl Input {
         }
     }
 
+    /// Presents a series of options to the user from which they can choose one.
+    ///
+    /// This function will guarantee that the user chooses something present in `opts`
+    ///
+    /// This function can return `Err` if the user's option doesn't parse into `T`
+    ///
+    /// Example:
+    /// ```
+    /// let choice: String = Input::new()
+    ///     .wait_opts(&["First", "Second", "Third"], "Enter your choice: ")
+    ///     .unwrap();
+    ///
+    /// match choice.as_str() {
+    ///     "First" => println!("1st!"),
+    ///     "Second" => println!("2nd"),
+    ///     "Third" => println!("3rd..")
+    /// }
+    /// ```
+    ///
+    /// The user in the above case would see the following:
+    /// ```markdown
+    /// 1. First
+    /// 2. Second
+    /// 3. Third
+    /// Enter your choice:
+    /// ```
+    pub fn wait_opts<T>(&self, opts: &[&str], p: &str) -> Result<T, T::Err>
+    where
+        T: std::str::FromStr,
+    {
+        let index;
+
+        // This is so that the input object will respect err_msg rules and quit triggers
+        let mut ic = self.clone();
+
+        loop {
+            for (i, v) in opts.iter().enumerate() {
+                println!("{}. {}", i + 1, v);
+            }
+
+            let result = ic.prompt(p).wait();
+
+            if (1..=opts.len()).contains(&result) {
+                index = result - 1;
+                break;
+            } else {
+                println!(
+                    "Please enter a number within the bounds {:?}",
+                    1..=opts.len()
+                );
+            }
+        }
+
+        opts[index].parse()
+    }
+
     /// Similar to `wait`, except will return after the user inputs anything.
     ///
     /// If the user input doesn't parse to `T`, `None` is returned.


### PR DESCRIPTION
This change adds "options"; aka, the following will now be possible without needing to roll a custom solution:

```rust
let choice: u32 = Input::new()
    .wait_opts(&["13", "15", "17"], "Number to choose: ")
    .unwrap();

println!("You chose: {}", choice); // This will be one of 13, 15, or 17
```